### PR TITLE
Support <IE10

### DIFF
--- a/lib/indexing.js
+++ b/lib/indexing.js
@@ -42,7 +42,7 @@ if (Meteor.isServer) {
       });
     }
 
-    const propName = ss.version === 2 ? 'mergedSchema' : 'schema';
+    var propName = ss.version === 2 ? 'mergedSchema' : 'schema';
 
     // Loop over fields definitions and ensure collection indexes (server side only)
     _.each(ss[propName](), function(definition, fieldName) {


### PR DESCRIPTION
IE 10 does not support the `const` keyword.
This is needed when using the https://github.com/thereactivestack/meteor-webpack package instead of ecmascript